### PR TITLE
Tooltip changes and fixes

### DIFF
--- a/Constants/Constants.lua
+++ b/Constants/Constants.lua
@@ -4864,5 +4864,23 @@ constants.TOOLTIP = {
     COMMS_PREFIX = {
         SEND_DATA = "TOOLTIP_DATA",
         REQUEST_DATA = "TOOLTIP_REQUEST",
-    }
+    },
+    THREADS_COLORS = {
+        {COLOR = CreateColorFromHexString("FF9b59b6"), MILESTONE = 0 }, -- Placeholder
+
+        --- As soon as we have information on how much is good, we can adjust these milestones and uncomment
+        --{COLOR = CreateColorFromHexString("FFe74c3c"), MILESTONE = 0 }, -- Beginner
+        --{COLOR = CreateColorFromHexString("FFe67e22"), MILESTONE = 0 }, -- Poor
+        --{COLOR = CreateColorFromHexString("FFf1c40f"), MILESTONE = 0 }, -- Decent
+        --{COLOR = CreateColorFromHexString("FF1abc9c"), MILESTONE = 0 }, -- Good
+        --{COLOR = CreateColorFromHexString("FF2ecc71"), MILESTONE = 0 }, -- Best
+    },
+    INFINITE_POWER_COLORS = {
+        -- We should probably adjust these as we get more information
+        {COLOR = CreateColorFromHexString("FFe74c3c"), MILESTONE = 0 }, -- Beginner
+        {COLOR = CreateColorFromHexString("FFe67e22"), MILESTONE = 250000 }, -- Unlimited Power IV
+        {COLOR = CreateColorFromHexString("FFf1c40f"), MILESTONE = 500000 }, -- Unlimited Power V
+        {COLOR = CreateColorFromHexString("FF1abc9c"), MILESTONE = 1000000 }, -- Unlimited Power VII
+        {COLOR = CreateColorFromHexString("FF2ecc71"), MILESTONE = 5000000 }, -- Unlimited Power XII
+    },
 }

--- a/LegionRemixHelper.toc
+++ b/LegionRemixHelper.toc
@@ -1,5 +1,5 @@
 ## Interface: 110200, 110205
-## Version: 1.2.1
+## Version: 1.2.2
 ## Title: Legion Remix Helper
 ## Author: Rasu | Larsj_02
 ## DefaultState: enabled


### PR DESCRIPTION
Version bump,
Colored Tooltip Values for Threads and Power,
Fixes for Settings Localization Error,
Now Instantly get Player Power instead of requesting through comms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tooltips now show Threads and Power with milestone-based colorization and compact abbreviations.
  - Estimated Power ranges display colored min/max values for clearer readability.
  - Player Power is fetched directly when available; non-player units request data automatically for more accurate tooltips.
  - Added new color tiers to improve tooltip visuals at different progression levels.

- Chores
  - Updated addon version to 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->