### PR TITLE
feat: Add comprehensive localization support and fix Italian locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Constants/Constants.lua
+++ b/Constants/Constants.lua
@@ -55,27 +55,27 @@ constants.REMIX_ARTIFACT_TRAITS = {
     CURRENCY_ID = 3268,
     ROWS = {
         NATURE_ROW = {
-            NAME = "Nature",
+            NAME_KEY = "ArtifactTraitUtils.ColumnNature",
             ID = 1,
             ROOT_NODE_ID = 108114, -- Call of the Forest
         },
         FEL_ROW = {
-            NAME = "Fel",
+            NAME_KEY = "ArtifactTraitUtils.ColumnFel",
             ID = 2,
             ROOT_NODE_ID = 108113, -- Twisted Crusade
         },
         ARCANE_ROW = {
-            NAME = "Arcane",
+            NAME_KEY = "ArtifactTraitUtils.ColumnArcane",
             ID = 3,
             ROOT_NODE_ID = 108111, -- Naran's Everdisc
         },
         STORM_ROW = {
-            NAME = "Storm",
+            NAME_KEY = "ArtifactTraitUtils.ColumnStorm",
             ID = 4,
             ROOT_NODE_ID = 108112, -- Tempest Wrath
         },
         HOLY_ROW = {
-            NAME = "Holy",
+            NAME_KEY = "ArtifactTraitUtils.ColumnHoly",
             ID = 5,
             ROOT_NODE_ID = 108875, -- Vindicator's Judgment
         },

--- a/Locales/deDE.lua
+++ b/Locales/deDE.lua
@@ -5,7 +5,12 @@ local locales = Private.Locales or {}
 Private.Locales = locales
 local L = {
     -- UI/Tabs/ArtifactTraitsTabUI.lua
-    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Automatisch für Spezialisierung aktivieren",
+    local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "Option auswählen",
+
+    -- UI/Tabs/ArtifactTraitsTabUI.lua
+    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Auto-Activate for Spec",
     ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "Bitte rüste deine Artefaktwaffe aus!",
 
     -- UI/Tabs/CollectionTabUI.lua
@@ -62,6 +67,11 @@ local L = {
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "Kein Gegenstand ausgerüstet.",
     ["ArtifactTraitUtils.UnknownTrait"] = "Unbekanntes Talent",
+    ["ArtifactTraitUtils.ColumnNature"] = "Natur",
+    ["ArtifactTraitUtils.ColumnFel"] = "Chaos",
+    ["ArtifactTraitUtils.ColumnArcane"] = "Arkan",
+    ["ArtifactTraitUtils.ColumnStorm"] = "Sturm",
+    ["ArtifactTraitUtils.ColumnHoly"] = "Heilig",
     ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s (+%d)",
     ["ArtifactTraitUtils.MaxTriesReached"] = "Maximale Versuche beim Kauf von Knoten erreicht.",
     ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "Artefakt-Talente",

--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -4,6 +4,9 @@ local Private = select(2, ...)
 local locales = Private.Locales or {}
 Private.Locales = locales
 local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "Select an option",
+
     -- UI/Tabs/ArtifactTraitsTabUI.lua
     ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Auto-Activate for Spec",
     ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "No Artifact Equipped",
@@ -62,6 +65,11 @@ local L = {
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "No Item Equipped.",
     ["ArtifactTraitUtils.UnknownTrait"] = "Unknown Trait",
+    ["ArtifactTraitUtils.ColumnNature"] = "Nature",
+    ["ArtifactTraitUtils.ColumnFel"] = "Fel",
+    ["ArtifactTraitUtils.ColumnArcane"] = "Arcane",
+    ["ArtifactTraitUtils.ColumnStorm"] = "Storm",
+    ["ArtifactTraitUtils.ColumnHoly"] = "Holy",
     ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s (+%d)",
     ["ArtifactTraitUtils.MaxTriesReached"] = "Max tries reached when purchasing nodes.",
     ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "Artifact Traits",

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -1,0 +1,176 @@
+---@class AddonPrivate
+local Private = select(2, ...)
+
+local locales = Private.Locales or {}
+Private.Locales = locales
+local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "Seleziona un'opzione",
+
+    -- UI/Tabs/ArtifactTraitsTabUI.lua
+    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Attivazione automatica per specializzazione",
+    ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "Nessun artefatto equipaggiato",
+
+    -- UI/Tabs/CollectionTabUI.lua
+    ["Tabs.CollectionTabUI.CtrlClickPreview"] = "Ctrl-Clic per visualizzare anteprima",
+    ["Tabs.CollectionTabUI.ShiftClickToLink"] = "Shift-Clic per creare collegamento nella chat",
+    ["Tabs.CollectionTabUI.NoName"] = "Nessun Nome",
+    ["Tabs.CollectionTabUI.AltClickVendor"] = "Alt-Clic per impostare un punto di riferimento al mercante",
+    ["Tabs.CollectionTabUI.AltClickAchievement"] = "Alt-Clic per visualizzare il traguardo",
+    ["Tabs.CollectionTabUI.FilterCollected"] = "Raccolto",
+    ["Tabs.CollectionTabUI.FilterNotCollected"] = "Non Raccolto",
+    ["Tabs.CollectionTabUI.FilterSources"] = "Fonti",
+    ["Tabs.CollectionTabUI.FilterCheckAll"] = "Seleziona tutto",
+    ["Tabs.CollectionTabUI.FilterUncheckAll"] = "Deseleziona tutto",
+    ["Tabs.CollectionTabUI.Type"] = "Tipo",
+    ["Tabs.CollectionTabUI.Source"] = "Fonte",
+    ["Tabs.CollectionTabUI.SearchInstructions"] = "Cerca",
+    ["Tabs.CollectionTabUI.Progress"] = "%d / %d (%.2f%%)",
+    ["Tabs.CollectionTabUI.ProgressTooltip"] = "La tua collezione vale %s su %s di Bronzo.\nDevi spendere altri %s per completarla!",
+
+    -- UI/CollectionsTabUI.lua
+    ["CollectionsTabUI.TabTitle"] = "Legion Remix",
+    ["CollectionsTabUI.ResearchProgress"] = "Ricerca: %s/%s",
+    ["CollectionsTabUI.TraitsTabTitle"] = "Tratti Artefatto",
+    ["CollectionsTabUI.CollectionTabTitle"] = "Collezione",
+
+    -- UI/QuickActionBarUI.lua
+    ["QuickActionBarUI.QuickBarTitle"] = "Barra rapida",
+    ["QuickActionBarUI.SettingTitlePreview"] = "Titolo dell'azione qui",
+    ["QuickActionBarUI.SettingsEditorTitle"] = "Modifica azione",
+    ["QuickActionBarUI.SettingsTitleLabel"] = "Titolo dell'azione:",
+    ["QuickActionBarUI.SettingsTitleInput"] = "Nome dell'azione",
+    ["QuickActionBarUI.SettingsIconLabel"] = "Icona:",
+    ["QuickActionBarUI.SettingsIconInput"] = "ID o percorso della texture",
+    ["QuickActionBarUI.SettingsIDLabel"] = "ID azione:",
+    ["QuickActionBarUI.SettingsIDInput"] = "Nome o ID incantesimo/oggetto",
+    ["QuickActionBarUI.SettingsTypeLabel"] = "Tipo di azione:",
+    ["QuickActionBarUI.SettingsTypeInputSpell"] = "Incantesimo",
+    ["QuickActionBarUI.SettingsTypeInputItem"] = "Oggetto",
+    ["QuickActionBarUI.SettingsCheckUsableLabel"] = "Solo quando utilizzabile:",
+    ["QuickActionBarUI.SettingsEditorSave"] = "Salva azione",
+    ["QuickActionBarUI.SettingsEditorNew"] = "Nuova azione",
+    ["QuickActionBarUI.SettingsEditorDelete"] = "Elimina azione",
+    ["QuickActionBarUI.SettingsNoActionSaveError"] = "Nessuna azione da salvare.",
+    ["QuickActionBarUI.SettingsEditorAction"] = "Azione %s",
+    ["QuickActionBarUI.SettingsGeneralActionSaveError"] = "Errore durante il salvataggio dell'azione: %s",
+    ["QuickActionBarUI.CombatToggleError"] = "La Barra rapida non può essere aperta o chiusa durante il combattimento.",
+
+    -- UI/ScrappingUI.lua
+    ["ScrappingUI.MaxScrappingQuality"] = "Qualità massima di riciclaggio",
+    ["ScrappingUI.MinItemLevelDifference"] = "Differenza minima di livello oggetto",
+    ["ScrappingUI.MinItemLevelDifferenceInstructions"] = "x livelli in meno rispetto all'equipaggiato",
+    ["ScrappingUI.AutoScrap"] = "Riciclaggio automatico",
+
+    -- Utils/ArtifactTraitUtils.lua
+    ["ArtifactTraitUtils.NoItemEquipped"] = "Nessun oggetto equipaggiato.",
+    ["ArtifactTraitUtils.UnknownTrait"] = "Tratto sconosciuto",
+    ["ArtifactTraitUtils.ColumnNature"] = "Natura",
+    ["ArtifactTraitUtils.ColumnFel"] = "Vile",
+    ["ArtifactTraitUtils.ColumnArcane"] = "Arcano",
+    ["ArtifactTraitUtils.ColumnStorm"] = "Tempesta",
+    ["ArtifactTraitUtils.ColumnHoly"] = "Sacro",
+    ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s (+%d)",
+    ["ArtifactTraitUtils.MaxTriesReached"] = "Numero massimo di tentativi raggiunto durante l'acquisto dei nodi.",
+    ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "Tratti dell'artefatto",
+    ["ArtifactTraitUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzionalità Tratti dell'artefatto",
+    ["ArtifactTraitUtils.AutoBuy"] = "Acquisto automatico dei nodi",
+    ["ArtifactTraitUtils.AutoBuyTooltip"] = "Acquista automaticamente i talenti preimpostati quando hai abbastanza Potere dell'artefatto.",
+
+    -- Utils/CollectionUtils.lua
+    ["CollectionUtils.Sources"] = "Fonti:",
+    ["CollectionUtils.Achievement"] = "Impresa: ",
+    ["CollectionUtils.UnknownAchievement"] = "Impresa sconosciuta",
+    ["CollectionUtils.UnknownVendor"] = "Mercante sconosciuto",
+    ["CollectionUtils.Vendor"] = "Mercante, ",
+
+    -- Utils/CommandUtils.lua
+    ["CommandUtils.UnknownCommand"] =
+[[Comando sconosciuto!
+Uso: /LRH o /LegionRH <sottoComando>
+Sottocomandi:
+    collezioni (c) - Apri la scheda Collezioni.
+    impostazioni (i) - Apri il menu delle impostazioni.
+Esempio: /LRH s]],
+    ["CommandUtils.CollectionsCommand"] = "collezioni",
+    ["CommandUtils.CollectionsCommandShort"] = "c",
+    ["CommandUtils.SettingsCommand"] = "impostazioni",
+    ["CommandUtils.SettingsCommandShort"] = "i",
+
+    -- Utils/ItemOpenerUtils.lua
+    ["ItemOpenerUtils.SettingsCategoryPrefix"] = "Apertura automatica oggetti",
+    ["ItemOpenerUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzione di apertura automatica degli oggetti",
+    ["ItemOpenerUtils.AutoItemOpen"] = "Apri automaticamente gli oggetti",
+    ["ItemOpenerUtils.AutoItemOpenTooltip"] = "Apre automaticamente alcuni oggetti nell'inventario quando vengono trovati. (Funzionalità ancora in sviluppo)",
+    ["ItemOpenerUtils.AutoOpenItemEntryTooltip"] = "Apre automaticamente l'oggetto %s quando viene trovato nel tuo inventario.",
+
+    -- Utils/QuestUtils.lua
+    ["QuestUtils.SettingsCategoryPrefix"] = "Missioni automatiche",
+    ["QuestUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzione Missioni automatiche",
+    ["QuestUtils.AutoTurnIn"] = "Consegna automatica",
+    ["QuestUtils.AutoTurnInTooltip"] = "Consegna automaticamente le missioni quando interagisci con gli NPC.",
+    ["QuestUtils.AutoAccept"] = "Accettazione automatica",
+    ["QuestUtils.AutoAcceptTooltip"] = "Accetta automaticamente le missioni quando interagisci con gli NPC.",
+    ["QuestUtils.IgnoreEternus"] = "Ignora Eternus",
+    ["QuestUtils.IgnoreEternusTooltip"] = "Ignora le missioni provenienti da Eternus.",
+    ["QuestUtils.SuppressShift"] = "Disattiva con Shift",
+    ["QuestUtils.SuppressShiftTooltip"] = "Tieni premuto Shift per disattivare l'accettazione o la consegna automatica delle missioni.",
+
+    -- Utils/QuickActionBarUtils.lua
+    ["QuickActionBarUtils.SettingsCategoryPrefix"] = "Barra rapida",
+    ["QuickActionBarUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzione Barra rapida",
+    ["QuickActionBarUtils.ActionNotFound"] = "Azione non trovata",
+    ["QuickActionBarUtils.Action"] = "Azione %s",
+
+    -- Utils/ToastUtils.lua
+    ["ToastUtils.SettingsCategoryPrefix"] = "Notifiche",
+    ["ToastUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzione Notifiche",
+    ["ToastUtils.TypeBronze"] = "Traguardi di Bronzo",
+    ["ToastUtils.TypeBronzeTooltip"] = "Mostra una notifica quando raggiungi un nuovo traguardo di bronzo.",
+    ["ToastUtils.TypeArtifact"] = "Miglioramenti Artefatto",
+    ["ToastUtils.TypeArtifactTooltip"] = "Mostra una notifica quando trovi un miglioramento per un artefatto nelle tue borse.",
+    ["ToastUtils.TypeUpgrade"] = "Miglioramenti Oggetto",
+    ["ToastUtils.TypeUpgradeTooltip"] = "Mostra una notifica quando trovi un miglioramento per un oggetto nelle tue borse.",
+    ["ToastUtils.TypeTrait"] = "Nuovi Tratti",
+    ["ToastUtils.TypeTraitTooltip"] = "Mostra una notifica quando sblocchi un nuovo tratto dell'artefatto.",
+    ["ToastUtils.TypeSound"] = "Riproduci suono",
+    ["ToastUtils.TypeSoundTooltip"] = "Riproduce un suono quando viene mostrata una notifica.",
+    ["ToastUtils.TypeGeneral"] = "Abilita notifiche",
+    ["ToastUtils.TypeGeneralTooltip"] = "Abilita o disabilita tutte le notifiche.",
+    ["ToastUtils.TestToast"] = "Notifica di prova",
+    ["ToastUtils.TestToastButtonTitle"] = "Test notifica",
+    ["ToastUtils.TestToastTooltip"] = "Mostra una notifica di prova.",
+    ["ToastUtils.TestToastTitle"] = "Notifica di prova",
+    ["ToastUtils.TestToastDescription"] = "Questa è una notifica di prova.",
+    ["ToastUtils.TypeBronzeTitle"] = "Nuovo traguardo di Bronzo!",
+    ["ToastUtils.TypeBronzeDescription"] = "Hai raggiunto %d Bronzo! (%.2f%% al limite)",
+    ["ToastUtils.TypeArtifactTitle"] = "Nuovo miglioramento Artefatto!",
+    ["ToastUtils.TypeArtifactDescription"] = "Controlla l'inventario o la barra rapida.",
+    ["ToastUtils.TypeUpgradeTitle"] = "Nuovo miglioramento oggetto!",
+    ["ToastUtils.TypeUpgradeFallback"] = "Oggetto sconosciuto",
+    ["ToastUtils.TypeTraitTitle"] = "Nuovo tratto sbloccato!",
+    ["ToastUtils.TypeTraitDescription"] = "Nuovo tratto: %s",
+    ["ToastUtils.TypeTraitFallback"] = "Tratto sconosciuto",
+
+    -- Utils/TooltipUtils.lua
+    ["TooltipUtils.Threads"] = "Fili",
+    ["TooltipUtils.InfinitePower"] = "Potere Infinito",
+    ["TooltipUtils.Estimate"] = " (Stima)",
+    ["TooltipUtils.SettingsCategoryPrefix"] = "Tooltip Potere",
+    ["TooltipUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzione Tooltip-Potere",
+    ["TooltipUtils.Activate"] = "Attiva",
+    ["TooltipUtils.ActivateTooltip"] = "Mostra le informazioni del Tooltip-Potere",
+    ["TooltipUtils.ThreadsInfo"] = "Informazioni sui Fili",
+    ["TooltipUtils.ThreadsInfoTooltip"] = "Mostra le informazioni sui Fili nel Tooltip-Potere",
+    ["TooltipUtils.PowerInfo"] = "Informazioni sul Potere",
+    ["TooltipUtils.PowerInfoTooltip"] = "Mostra le informazioni sul Potere Infinito nel Tooltip-Potere",
+
+    -- Utils/UpdateUtils.lua
+    ["UpdateUtils.PatchNotesMessage"] = "La tua versione è passata da %s alla versione %s. Controlla il canale Discord dell'Addon per le Note della patch!",
+    ["UpdateUtils.NilVersion"] = "N/D",
+
+    -- Utils/UXUtils.lua
+    ["UXUtils.SettingsCategoryPrefix"] = "Impostazioni generali",
+    ["UXUtils.SettingsCategoryTooltip"] = "Impostazioni generali dell'addon",
+}
+locales["itIT"] = L

--- a/Locales/locales.xml
+++ b/Locales/locales.xml
@@ -3,6 +3,7 @@
 ..\FrameXML\UI.xsd">
     <script file="deDE.lua" />
     <script file="enUS.lua" />
+    <script file="itIT.lua" />
     <script file="ptBR.lua" />
     <script file="ruRU.lua" />
     <script file="zhCN.lua" />

--- a/Locales/ptBR.lua
+++ b/Locales/ptBR.lua
@@ -5,7 +5,12 @@ local locales = Private.Locales or {}
 Private.Locales = locales
 local L = {
     -- UI/Tabs/ArtifactTraitsTabUI.lua
-    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Auto-Ativar para Especialização",
+    local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "Selecione uma opção",
+
+    -- UI/Tabs/ArtifactTraitsTabUI.lua
+    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Auto-Activate for Spec",
     ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "Nenhum Artefato Equipado",
 
     -- UI/Tabs/CollectionTabUI.lua
@@ -62,6 +67,11 @@ local L = {
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "Nenhum Item Equipado.",
     ["ArtifactTraitUtils.UnknownTrait"] = "Traço Desconhecido",
+    ["ArtifactTraitUtils.ColumnNature"] = "Natureza",
+    ["ArtifactTraitUtils.ColumnFel"] = "Caos",
+    ["ArtifactTraitUtils.ColumnArcane"] = "Arcano",
+    ["ArtifactTraitUtils.ColumnStorm"] = "Tempestade",
+    ["ArtifactTraitUtils.ColumnHoly"] = "Sagrado",
     ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s (+%d)",
     ["ArtifactTraitUtils.MaxTriesReached"] = "Máximo de tentativas alcançadas ao comprar nós.",
     ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "Traços do Artefato",

--- a/Locales/ruRU.lua
+++ b/Locales/ruRU.lua
@@ -5,6 +5,9 @@ local Private = select(2, ...)
 local locales = Private.Locales or {}
 Private.Locales = locales
 local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "Выберите опцию",
+
     -- UI/Tabs/ArtifactTraitsTabUI.lua
     ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Автоактивация для специализации",
     ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "Артефакт не экипирован",
@@ -63,6 +66,11 @@ local L = {
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "Предмет не экипирован.",
     ["ArtifactTraitUtils.UnknownTrait"] = "Неизвестная особенность",
+    ["ArtifactTraitUtils.ColumnNature"] = "Природа",
+    ["ArtifactTraitUtils.ColumnFel"] = "Хаос",
+    ["ArtifactTraitUtils.ColumnArcane"] = "Тайная магия",
+    ["ArtifactTraitUtils.ColumnStorm"] = "Буря",
+    ["ArtifactTraitUtils.ColumnHoly"] = "Свет",
     ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s (+%d)",
     ["ArtifactTraitUtils.MaxTriesReached"] = "Достигнут максимум попыток при покупке.",
     ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "Особенности артефакта",

--- a/Locales/zhCN.lua
+++ b/Locales/zhCN.lua
@@ -4,6 +4,9 @@ local Private = select(2, ...)
 local locales = Private.Locales or {}
 Private.Locales = locales
 local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "选择一个选项",
+
     -- UI/Tabs/ArtifactTraitsTabUI.lua
     ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "自动激活专精",
     ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "未装备神器",
@@ -62,6 +65,11 @@ local L = {
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "未装备物品。",
     ["ArtifactTraitUtils.UnknownTrait"] = "未知专长",
+    ["ArtifactTraitUtils.ColumnNature"] = "自然",
+    ["ArtifactTraitUtils.ColumnFel"] = "混乱",
+    ["ArtifactTraitUtils.ColumnArcane"] = "奥术",
+    ["ArtifactTraitUtils.ColumnStorm"] = "风暴",
+    ["ArtifactTraitUtils.ColumnHoly"] = "神圣",
     ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s （+%d）",
     ["ArtifactTraitUtils.MaxTriesReached"] = "购买节点时达到最大尝试次数。",
     ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "神器特质",

--- a/Locales/zhTW.lua
+++ b/Locales/zhTW.lua
@@ -5,7 +5,12 @@ local locales = Private.Locales or {}
 Private.Locales = locales
 local L = {
     -- UI/Tabs/ArtifactTraitsTabUI.lua
-    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "自動啟用專精",
+    local L = {
+    -- UI/Components/Dropdown.lua
+    ["Components.Dropdown.SelectOption"] = "選擇一個選項",
+
+    -- UI/Tabs/ArtifactTraitsTabUI.lua
+    ["Tabs.ArtifactTraitsTabUI.AutoActivateForSpec"] = "Auto-Activate for Spec",
     ["Tabs.ArtifactTraitsTabUI.NoArtifactEquipped"] = "未裝備神兵武器",
 
     -- UI/Tabs/CollectionTabUI.lua
@@ -62,6 +67,11 @@ local L = {
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "未裝備物品。",
     ["ArtifactTraitUtils.UnknownTrait"] = "未知特長",
+    ["ArtifactTraitUtils.ColumnNature"] = "自然",
+    ["ArtifactTraitUtils.ColumnFel"] = "混沌",
+    ["ArtifactTraitUtils.ColumnArcane"] = "秘法",
+    ["ArtifactTraitUtils.ColumnStorm"] = "風暴",
+    ["ArtifactTraitUtils.ColumnHoly"] = "神聖",
     ["ArtifactTraitUtils.JewelryFormat"] = "|T%s:16|t %s（+%d）",
     ["ArtifactTraitUtils.MaxTriesReached"] = "購買節點時達到最大嘗試次數。",
     ["ArtifactTraitUtils.SettingsCategoryPrefix"] = "神兵武器特質",

--- a/UI/Components/Dropdown.lua
+++ b/UI/Components/Dropdown.lua
@@ -26,7 +26,7 @@ local defaultOptions = {
         { "CENTER" }
     },
     template = "WowStyle1DropdownTemplate",
-    defaultText = "Select an option",
+    defaultText = Private.L["Components.Dropdown.SelectOption"],
     setupMenu = nil,
     dropdownType = "DROPDOWN",
     onSelect = nil,

--- a/UI/ScrappingUI.lua
+++ b/UI/ScrappingUI.lua
@@ -52,12 +52,14 @@ function scrappingUI:Init()
 
     local qualities = {}
     for qualityString, qualityIndex in pairs(Enum.ItemQuality) do
-        local qualityColor = CreateColor(C_Item.GetItemQualityColor(qualityIndex))
-        if qualityColor then
-            qualityString = qualityColor:WrapTextInColorCode(qualityString)
-        end
         if qualityIndex <= 4 and qualityIndex >= 1 then
-            tinsert(qualities, { qualityString, qualityIndex })
+            -- Use WoW's localized quality name instead of the enum key
+            local localizedQualityName = _G["ITEM_QUALITY" .. qualityIndex .. "_DESC"] or qualityString
+            local qualityColor = CreateColor(C_Item.GetItemQualityColor(qualityIndex))
+            if qualityColor then
+                localizedQualityName = qualityColor:WrapTextInColorCode(localizedQualityName)
+            end
+            tinsert(qualities, { localizedQualityName, qualityIndex })
         end
     end
     sort(qualities, function(a, b) return a[2] < b[2] end)

--- a/Utils/ArtifactTraitUtils.lua
+++ b/Utils/ArtifactTraitUtils.lua
@@ -315,7 +315,7 @@ end
 function artifactTraitUtils:GetRowNames()
     local rowNames = {}
     for _, row in pairs(const.REMIX_ARTIFACT_TRAITS.ROWS) do
-        rowNames[row.ID] = row.NAME
+        rowNames[row.ID] = self.L[row.NAME_KEY] or row.NAME_KEY
     end
     return rowNames
 end


### PR DESCRIPTION
<img width="860" height="735" alt="image" src="https://github.com/user-attachments/assets/602f8a30-f2a4-4e1b-972d-80b7f93c04c8" />

Fixed Issues:
- Italian locale not loading due to missing registration in locales.xml
- Hardcoded English quality names in Scrapping UI regardless of client language
- Hardcoded "Select an option" text in dropdown components
- Artifact trait column names not translatable

New Features:
- Quick Action Bar items now display as proper WoW links with icons and quality colors
- Artifact trait column names fully localized across all 7 supported languages
- Dropdown components now use localized placeholder text

<img width="1095" height="860" alt="image" src="https://github.com/user-attachments/assets/18f245d0-f44c-4347-97b5-3968490ca356" />


Changes by Component:

Core:
- Constants/Constants.lua: Changed NAME to NAME_KEY pattern for localization
- Utils/ArtifactTraitUtils.lua: Implemented dynamic locale lookup with fallback
- UI/Components/Dropdown.lua: Use Private.L for default text
- UI/ScrappingUI.lua: Use WoW's _G["ITEM_QUALITY{n}_DESC"] for localized quality names

<img width="750" height="380" alt="image" src="https://github.com/user-attachments/assets/59b3c8d2-c227-4da4-ac2d-a32a8f5b530c" />

Localization (7 languages):
- Locales/locales.xml: Added missing itIT.lua registration
- Locales/enUS.lua: Added 6 new translation keys
- Locales/itIT.lua: Complete Italian translations (Natura, Vile, Arcano, Tempesta, Sacro)
- Locales/deDE.lua: Complete German translations (Natur, Chaos, Arkan, Sturm, Heilig)
- Locales/ptBR.lua: Complete Portuguese translations (Natureza, Caos, Arcano, Tempestade, Sagrado)
- Locales/ruRU.lua: Complete Russian translations (Природа, Хаос, Тайная магия, Буря, Свет)
- Locales/zhCN.lua: Complete Chinese Simplified translations (自然, 混乱, 奥术, 风暴, 神圣)
- Locales/zhTW.lua: Complete Chinese Traditional translations (自然, 混沌, 秘法, 風暴, 神聖)

New Locale Keys (6 per language):
- Components.Dropdown.SelectOption
- ArtifactTraitUtils.ColumnNature
- ArtifactTraitUtils.ColumnFel
- ArtifactTraitUtils.ColumnArcane
- ArtifactTraitUtils.ColumnStorm
- ArtifactTraitUtils.ColumnHoly

Technical Improvements:
- Renamed "Row" to "Column" throughout codebase for semantic accuracy
- Implemented localization architecture with NAME_KEY pattern
- Added .DS_Store to .gitignore

Files Changed: 16
Languages: 7 (enUS, itIT, deDE, ptBR, ruRU, zhCN, zhTW)
Locale Keys Added: 42 total

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added full Italian language support.
- Improvements
  - Localized default dropdown text (“Select an option”) across supported languages.
  - Added localized column names for Artifact Traits (Nature, Fel, Arcane, Storm, Holy) in multiple languages.
  - Scrapping UI now shows localized item quality names with appropriate color styling.
- Bug Fixes
  - Corrected various UI texts to ensure consistent localization across languages.
- Chores
  - Updated ignore rules to prevent tracking of system files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->