### PR TITLE
fix item opener locking multiple items

### DIFF
--- a/Utils/ItemOpenerUtils.lua
+++ b/Utils/ItemOpenerUtils.lua
@@ -98,6 +98,7 @@ function itemOpenerUtils:OpenBagItems()
     for itemLoc in self.itemUtils:ForEachBagItem() do
         if self:IsAutoItem(itemLoc) then
             C_Container.UseContainerItem(itemLoc:GetBagAndSlot())
+            return -- after opening we will get another BAG_UPDATE_DELAYED. stop here to avoid Locked items
         end
     end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where auto-opening multiple items in one pass could cause lock errors or inconsistent behavior.
  * Now opens a single item per cycle to prevent conflicts triggered by delayed bag updates.
  * Improves reliability and reduces interruptions when auto-opening items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->