### PR TITLE
Update Italian localization and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore macOS .DS_Store files in all directories
+**/.DS_Store

--- a/Locales/itIT.lua
+++ b/Locales/itIT.lua
@@ -22,6 +22,8 @@ local L = {
     ["Tabs.CollectionTabUI.FilterSources"] = "Fonti",
     ["Tabs.CollectionTabUI.FilterCheckAll"] = "Seleziona tutto",
     ["Tabs.CollectionTabUI.FilterUncheckAll"] = "Deseleziona tutto",
+    ["Tabs.CollectionTabUI.FilterRaidVariants"] = "Mostra varianti incursione",
+    ["Tabs.CollectionTabUI.FilterUnique"] = "Solo oggetti specifici Remix",
     ["Tabs.CollectionTabUI.Type"] = "Tipo",
     ["Tabs.CollectionTabUI.Source"] = "Fonte",
     ["Tabs.CollectionTabUI.SearchInstructions"] = "Cerca",
@@ -61,15 +63,15 @@ local L = {
     ["ScrappingUI.MinItemLevelDifference"] = "Differenza minima di livello oggetto",
     ["ScrappingUI.MinItemLevelDifferenceInstructions"] = "x livelli in meno rispetto all'equipaggiato",
     ["ScrappingUI.AutoScrap"] = "Riciclaggio automatico",
-    ["ScrappingUI.ScraperListTabTitle"] = "Scrapper List",
-    ["ScrappingUI.AdvancedSettingsTabTitle"] = "More Settings",
-    ["ScrappingUI.JewelryTraitsToKeep"] = "Jewelry Traits to Keep",
-    ["ScrappingUI.AdvancedJewelryFilter"] = "Advanced Jewelry Filter",
-    ["ScrappingUI.FilterCheckAll"] = "Check All",
-    ["ScrappingUI.FilterUncheckAll"] = "Uncheck All",
-    ["ScrappingUI.Neck"] = "Neck traits",
-    ["ScrappingUI.Trinket"] = "Trinket traits",
-    ["ScrappingUI.Finger"] = "Ring traits",
+    ["ScrappingUI.ScraperListTabTitle"] = "Elenco di riciclo",
+    ["ScrappingUI.AdvancedSettingsTabTitle"] = "Altre impostazioni",
+    ["ScrappingUI.JewelryTraitsToKeep"] = "Tratti gioiello da mantenere",
+    ["ScrappingUI.AdvancedJewelryFilter"] = "Filtro gioiello avanzato",
+    ["ScrappingUI.FilterCheckAll"] = "Seleziona tutto",
+    ["ScrappingUI.FilterUncheckAll"] = "Deseleziona tutto",
+    ["ScrappingUI.Neck"] = "Tratti collana",
+    ["ScrappingUI.Trinket"] = "Tratti monile",
+    ["ScrappingUI.Finger"] = "Tratti anello",
 
     -- Utils/ArtifactTraitUtils.lua
     ["ArtifactTraitUtils.NoItemEquipped"] = "Nessun oggetto equipaggiato.",
@@ -107,9 +109,9 @@ Esempio: /LRH s]],
     ["CommandUtils.SettingsCommandShort"] = "i",
 
     -- Utils/EditModeUtils.lua
-    ["EditModeUtils.ShowAddonSystems"] = "Legion-Remix-Helper-Systems",
-    ["EditModeUtils.SystemLabel.ToastUI"] = "Toasts",
-    ["EditModeUtils.SystemTooltip.ToastUI"] = "Move the position of the toasts.",
+    ["EditModeUtils.ShowAddonSystems"] = "Assistente Legion Remix",
+    ["EditModeUtils.SystemLabel.ToastUI"] = "Notifiche",
+    ["EditModeUtils.SystemTooltip.ToastUI"] = "Sposta la posizione delle notifiche.",
 
     -- Utils/ItemOpenerUtils.lua
     ["ItemOpenerUtils.SettingsCategoryPrefix"] = "Apertura automatica oggetti",
@@ -117,6 +119,12 @@ Esempio: /LRH s]],
     ["ItemOpenerUtils.AutoItemOpen"] = "Apri automaticamente gli oggetti",
     ["ItemOpenerUtils.AutoItemOpenTooltip"] = "Apre automaticamente alcuni oggetti nell'inventario quando vengono trovati. (Funzionalità ancora in sviluppo)",
     ["ItemOpenerUtils.AutoOpenItemEntryTooltip"] = "Apre automaticamente l'oggetto %s quando viene trovato nel tuo inventario.",
+
+    -- Utils/MerchantUtils.lua
+    ["MerchantUtils.SettingsCategoryPrefix"] = "Impostazioni Mercante",
+    ["MerchantUtils.SettingsCategoryTooltip"] = "Impostazioni per la funzionalità Mercante",
+    ["MerchantUtils.HideCollectedMerchantItems"] = "Nascondi oggetti mercante raccolti",
+    ["MerchantUtils.HideCollectedMerchantItemsTooltip"] = "Nasconde gli oggetti che hai già nella tua collezione dalla finestra del mercante.",
 
     -- Utils/QuestUtils.lua
     ["QuestUtils.SettingsCategoryPrefix"] = "Missioni automatiche",


### PR DESCRIPTION
Enhance the Italian locale by translating various UI strings and tooltips, while also adding a .gitignore file to exclude macOS .DS_Store files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Italian localization: added new Collection tab filters (Raid Variants, Unique).
  * Added Italian translations for Merchant settings, including “Hide collected merchant items.”
  * Updated Italian labels across Scrapping UI and Edit Mode (toasts) for clearer, consistent wording.

* **Chores**
  * Ignored macOS .DS_Store files across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->