### PR TITLE
Updated `scrappingUtils:GetFilteredScrappableItems`

### DIFF
--- a/Utils/ScrappingUtils.lua
+++ b/Utils/ScrappingUtils.lua
@@ -164,16 +164,16 @@ function scrappingUtils:GetFilteredScrappableItems(capReturn)
         local jewelryType = const.SCRAPPING_MACHINE.JEWELRY.INV_TYPES[item.invType]
         local itemID = C_Item.GetItemID(item.location)
         local highestItem, highestGeneral = self:GetHighestItemFromListByID(scrappableItems, itemID)
-        if self:GetAdvancedJeweleryFilter() and jewelryType then
-            local shouldKeep = self:GetTraitToKeepForSlot(jewelryType, itemID)
-            if not shouldKeep and item.quality <= maxQuality and highestGeneral ~= item then
-                tinsert(filteredItems, item)
-            elseif shouldKeep and item.quality <= maxQuality and highestItem ~= item then
-                tinsert(filteredItems, item)
-            end
-        else
-            local equippedItemLevel = Private.ItemUtils:GetMinLevelForInvType(item.invType)
-            if equippedItemLevel and equippedItemLevel - item.level >= minLevelDiff and item.quality <= maxQuality then
+        local equippedItemLevel = Private.ItemUtils:GetMinLevelForInvType(item.invType)
+        if item.quality <= maxQuality and equippedItemLevel and equippedItemLevel - item.level >= minLevelDiff then
+            if self:GetAdvancedJeweleryFilter() and jewelryType then
+                local shouldKeep = self:GetTraitToKeepForSlot(jewelryType, itemID)
+                if not shouldKeep and highestGeneral ~= item then
+                    tinsert(filteredItems, item)
+                elseif shouldKeep and highestItem ~= item then
+                    tinsert(filteredItems, item)
+                end
+            else
                 tinsert(filteredItems, item)
             end
         end


### PR DESCRIPTION
`scrappingUtils:GetFilteredScrappableItems` now always takes max slot item level into account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized item filtering logic to evaluate quality and level requirements earlier in the process, improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->