### PR TITLE
fix: collections journal tab anchor

### DIFF
--- a/UI/CollectionsTabUI.lua
+++ b/UI/CollectionsTabUI.lua
@@ -38,11 +38,18 @@ end
 function collectionsTabUI:SetupTab()
     local addon = Private.Addon
 
-    local collectionsTab = CreateFrame("Button", "CollectionsJournalTab7", CollectionsJournal, "CollectionsJournalTab")
+    local lastCollectionsTab = CollectionsJournal.numTabs or 0
+    local lastCollectionsTabName = CollectionsJournal:GetName() .. "Tab" .. lastCollectionsTab
+    local nextFreeCollectionsTabName = CollectionsJournal:GetName() .. "Tab" .. lastCollectionsTab + 1
+
+    local collectionsTab = CreateFrame("Button", nextFreeCollectionsTabName, CollectionsJournal, "CollectionsJournalTab")
     collectionsTab:SetID(const.COLLECTIONS_TAB.TAB_ID)
     collectionsTab:SetText(self.L["CollectionsTabUI.TabTitle"])
-    collectionsTab:SetPoint("LEFT", CollectionsJournal.WarbandScenesTab, "RIGHT", 5, 0)
+    collectionsTab:SetPoint("LEFT", lastCollectionsTabName, "RIGHT", 3, 0)
     PanelTemplates_TabResize(collectionsTab)
+
+    -- Increase the numTabs count so other addons receive correct value
+    CollectionsJournal.numTabs = lastCollectionsTab + 1
 
     function collectionsTab:GetTextYOffset(isSelected)
         return isSelected and -3 or 2


### PR DESCRIPTION
With the current version, the anchoring of the Remix tab in the `CollectionsJournal` is messed up when there are other addons present registering their tabs.

<img width="769" height="190" alt="image" src="https://github.com/user-attachments/assets/97660773-eb1b-4a25-b547-ab76f297650c" />

This PR solves this issue by registering the tab by dynamically resolving the corresponding name and anchor.

<img width="868" height="171" alt="image" src="https://github.com/user-attachments/assets/34cbd71a-ac02-49d3-89c2-38f3dc77998a" />

Tested with [`SecureTabs-2.0`](https://github.com/Jaliborc/SecureTabs-2.0) version `11` and `12`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved collections tab creation system to use dynamic naming and positioning instead of hard-coded values, enabling more flexible and scalable tab management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->