### PR TITLE
chore: prefer using EasyScrap

### DIFF
--- a/LegionRemixHelper.toc
+++ b/LegionRemixHelper.toc
@@ -4,6 +4,7 @@
 ## Author: Rasu | Larsj_02
 ## DefaultState: enabled
 ## IconTexture: Interface\Addons\LegionRemixHelper\Media\Textures\logo.tga
+## OptionalDeps: EasyScrap
 ## SavedVariables: LegionRemixHelperDB
 ## SavedVariablesPerCharacter: LegionRemixHelperCharDB
 ## X-Curse-Project-ID: 1352479

--- a/UI/ScrappingUI.lua
+++ b/UI/ScrappingUI.lua
@@ -44,6 +44,9 @@ function scrappingUI:AddTab(name)
 end
 
 function scrappingUI:Init()
+    -- Prefer using EasyScrap if it's loaded
+    if C_AddOns.IsAddOnLoaded("EasyScrap") then return end
+
     self.scrappingMachine = ScrappingMachineFrame
     self.L = Private.L
     local addon = Private.Addon

--- a/Utils/ScrappingUtils.lua
+++ b/Utils/ScrappingUtils.lua
@@ -22,6 +22,9 @@ Private.ScrappingUtils = scrappingUtils
 local const = Private.constants
 
 function scrappingUtils:Init()
+    -- Prefer using EasyScrap if it's loaded
+    if C_AddOns.IsAddOnLoaded("EasyScrap") then return end
+
     self.ui = Private.ScrappingUI
 
     local addon = Private.Addon


### PR DESCRIPTION
This PR fixes "scrapping" errors caused by interference when `EasyScrap` addon is loaded. Default to use `EasyScrap` if its present.

Errors for reference:

```lua
4x ...ceLegionRemixHelper/Utils/ScrappingUtils.lua:234: attempt to index field 'scrappingMachine' (a nil value)
[LegionRemixHelper/Utils/ScrappingUtils.lua]:234: in function 'AutoScrap'
[LegionRemixHelper/Utils/ScrappingUtils.lua]:41: in function 'func'
[LegionRemixHelper/Libs/RasuLibs/RasuAddonBase.lua]:300: in function 'OnEvent'
[LegionRemixHelper/Libs/RasuLibs/RasuAddonBase.lua]:83: in function <...ns/LegionRemixHelper/Libs/RasuLibs/RasuAddonBase.lua:82>
[C]: ?
[C]: ?
[C]: in function 'UseContainerItem'
[EasyScrap/EasyScrap_Functions.lua]:91: in function 'addQueueItems'
[EasyScrap/EasyScrap_ItemDisplay.lua]:411: in function 'queueAllItems'
[EasyScrap/Frames/EasyScrapMainFrame.lua]:128: in function <...rfaceEasyScrap/Frames/EasyScrapMainFrame.lua:127>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added EasyScrap as an optional addon dependency in the manifest.

* **Bug Fixes**
  * Updated initialization routines to detect when EasyScrap addon is loaded and skip redundant setup operations accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->