### PR TITLE
Adds items to quick action bar

### DIFF
--- a/Constants/Constants.lua
+++ b/Constants/Constants.lua
@@ -4858,10 +4858,22 @@ do
         },
         {
             actionType = types.ITEM,
+            actionID = 248247,
+            checkVisibility = true,
+            title = "Cache of Infinite Power",  -- reward from Emissary quests
+        },
+        {
+            actionType = types.ITEM,
             actionID = 245553,
             checkVisibility = true,
             title = "Heroic Cache of Infinite Treasure",
             convert = true
+        },
+        {
+            actionType = types.ITEM,
+            actionID = 264675,
+            checkVisibility = true,
+            title = "Cache from the Infinite's Armory",
         },
         {
             actionType = types.ITEM,
@@ -4902,6 +4914,33 @@ do
             actionID = 249891,
             checkVisibility = true,
             title = "Mound of Artifactium Sand",
+        },
+        {
+            actionType = types.ITEM,
+            actionID = 246936,
+            checkVisibility = true,
+            title = "Resonant Epoch Memento",
+        },
+        {
+            actionType = types.ITEM,
+            actionID = 253227,
+            checkVisibility = true,
+            title = "Flawless Thread of Time",
+            minCount = 10,
+        },
+        {
+            actionType = types.ITEM,
+            actionID = 253224,
+            checkVisibility = true,
+            title = "Mote of a Broken Time",
+            minCount = 10,
+        },
+        {
+            actionType = types.ITEM,
+            actionID = 254267,
+            checkVisibility = true,
+            title = "Fragmented Memento of Epoch Challenges",
+            minCount = 100,
         },
         {
             actionType = types.ITEM,
@@ -4954,6 +4993,9 @@ do
             },
             {
                 ITEM_ID = 251821, -- Cache of Infinite Power
+            },
+            {
+                ITEM_ID = 248247, -- Cache of Infinite Power from Emissary quests
             },
             {
                 ITEM_ID = 245553, -- Heroic Cache of Infinite Treasure


### PR DESCRIPTION
1. items that consume multiple copies on use: Flawless Thread of Time, Mote of a Broken Time, Fragmented Memento of Epoch Challenges
2. Cache of Infinite Power with a different ID, reward from Emissary quests
3. Cache from the Infinite's Armory
4. Resonant Epoch Memento

To support the option table changes, code is added in `QuickActionBarUtils.lua` to invalidates option cache for existing users to be able to load the new options

To support items (1), an extra option 'minCount' is added to the table DEFAULT_ACTIONS and logic to handle it

items added:
<img width="272" height="289" alt="Snipaste_2025-12-13_13-04-07" src="https://github.com/user-attachments/assets/a8f8e4a8-d3e4-4c43-a158-ceabd42be972" />
<img width="352" height="268" alt="Snipaste_2025-12-13_13-03-48" src="https://github.com/user-attachments/assets/32e686a1-4e94-43c8-8117-947bd73f787e" />
<img width="276" height="293" alt="Snipaste_2025-12-13_13-03-39" src="https://github.com/user-attachments/assets/ceab64d1-5322-4446-ae11-8ae69726ead5" />
<img width="321" height="181" alt="Snipaste_2025-12-13_13-04-25" src="https://github.com/user-attachments/assets/666e73da-9329-4fe8-96ec-28c5dc7c529e" />
<img width="348" height="139" alt="Snipaste_2025-12-13_13-04-33" src="https://github.com/user-attachments/assets/e901cf94-b72c-402b-a038-b3a166c411ab" />
<img width="368" height="193" alt="Snipaste_2025-12-13_13-22-22" src="https://github.com/user-attachments/assets/8f7225ec-cd71-413e-8b3d-9f45d2b88d65" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new quick-action items: Cache of Infinite Power, Cache from the Infinite's Armory, Resonant Epoch Memento, Flawless Thread of Time, Mote of a Broken Time, and Fragmented Memento of Epoch Challenges
  * Quick-action items can now be configured with minimum count requirements before appearing in action bars

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->